### PR TITLE
Taint nodes and enable prefix delegation.

### DIFF
--- a/analytics/terraform/spark-k8s-operator/addons.tf
+++ b/analytics/terraform/spark-k8s-operator/addons.tf
@@ -510,15 +510,6 @@ module "eks_blueprints_addons" {
     aws-ebs-csi-driver = {
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
-    coredns = {
-      preserve = true
-    }
-    vpc-cni = {
-      preserve = true
-    }
-    kube-proxy = {
-      preserve = true
-    }
   }
 
   #---------------------------------------

--- a/analytics/terraform/spark-k8s-operator/eks.tf
+++ b/analytics/terraform/spark-k8s-operator/eks.tf
@@ -176,6 +176,14 @@ module "eks" {
         NodeGroupType = "spark_benchmark_ebs"
       }
 
+      taints = {
+        benchmark = {
+          key      = "spark-benchmark"
+          effect   = "NO_SCHEDULE"
+          operator = "EXISTS"
+        }
+      }  
+
       tags = {
         Name          = "spark_benchmark_ebs"
         NodeGroupType = "spark_benchmark_ebs"
@@ -222,7 +230,7 @@ module "eks" {
       }
 
       taints = {
-        gpu = {
+        benchmark = {
           key      = "spark-benchmark"
           effect   = "NO_SCHEDULE"
           operator = "EXISTS"

--- a/analytics/terraform/spark-k8s-operator/eks.tf
+++ b/analytics/terraform/spark-k8s-operator/eks.tf
@@ -30,6 +30,30 @@ module "eks" {
   ))
 
   #---------------------------------------
+  # Amazon EKS Managed Add-ons
+  #---------------------------------------
+  cluster_addons = {
+    coredns = {
+      preserve = true
+    }
+    vpc-cni = {
+      before_compute = true
+      preserve = true
+      most_recent    = true # To ensure access to the latest settings provided
+      configuration_values = jsonencode({
+        env = {
+          # Reference docs https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html
+          ENABLE_PREFIX_DELEGATION = "true"
+          WARM_PREFIX_TARGET       = "1"
+        }
+      })
+    }
+    kube-proxy = {
+      preserve = true
+    }
+  }
+
+  #---------------------------------------
   # Note: This can further restricted to specific required for each Add-on and your application
   #---------------------------------------
   # Extend cluster security group rules

--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/scale/README.md
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/scale/README.md
@@ -70,6 +70,39 @@ or
 locust --headless --only-summary -u 2 -r 1 --jobs-per-min 15 --jobs-limit 50
 ```
 
+To run the same test 3 times in a row with sleep in between
+```bash
+JOBS_MIN=-1
+JOBS_LIMIT=10
+TIMEOUT="7m"
+USERS=1
+RATE=1
+
+sleep 240
+locust --headless --only-summary -u $USERS -r $RATE -t $TIMEOUT --jobs-per-min $JOBS_MIN --jobs-limit $JOBS_LIMIT 2>&1 | tee -a load-test-$(date -u +"%Y-%m-%dT%H:%M:%SZ").log 
+
+echo "\n~~~~~~~~~~~~~~~~~~~~~~~Sleeping for 3min to separate tests~~~~~~~~~~~~~~~~~~~~~~\n"
+sleep 240
+
+locust --headless --only-summary -u $USERS -r $RATE -t $TIMEOUT --jobs-per-min $JOBS_MIN --jobs-limit $JOBS_LIMIT 2>&1 | tee -a load-test-$(date -u +"%Y-%m-%dT%H:%M:%SZ").log
+
+echo "\n~~~~~~~~~~~~~~~~~~~~~~~Sleeping for 3min to separate tests~~~~~~~~~~~~~~~~~~~~~~\\n"
+sleep 240
+
+locust --headless --only-summary -u $USERS -r $RATE -t $TIMEOUT --jobs-per-min $JOBS_MIN --jobs-limit $JOBS_LIMIT 2>&1 | tee -a load-test-$(date -u +"%Y-%m-%dT%H:%M:%SZ").log
+```
+
+to delete all of the nodes in the Spark ASG and start fresh you can run: 
+```bash
+for ID in $(aws autoscaling describe-auto-scaling-instances --output text \
+--query "AutoScalingInstances[?AutoScalingGroupName=='eks-spark_benchmark_ebs-20250203215338743800000001-aeca66e7-0385-19a7-a895-d021a5f67933'].InstanceId");
+do
+aws ec2 terminate-instances --instance-ids $ID
+done
+```
+
+```
+
 
 ### Docker image for SparkApplications
 

--- a/analytics/terraform/spark-k8s-operator/examples/benchmark/scale/spark-app-template.yaml
+++ b/analytics/terraform/spark-k8s-operator/examples/benchmark/scale/spark-app-template.yaml
@@ -32,11 +32,19 @@ spec:
     serviceAccount: spark-team-a
     nodeSelector:
       NodeGroupType: spark_benchmark_ebs
+    tolerations:
+      - key: spark-benchmark
+        operator: Exists
+        effect: NoSchedule
   executor:
     instances: 5
-    coreRequest: "0.1"
+    coreRequest: "0.01"
     cores: 1
     memory: 256m
     memoryOverhead: 0m
     nodeSelector:
       NodeGroupType: spark_benchmark_ebs
+    tolerations:
+      - key: spark-benchmark
+        operator: Exists
+        effect: NoSchedule


### PR DESCRIPTION
### What does this PR do?

This adds two changes to the blueprint:
1. Enables prefix mode on the VPC CNI. 
2. Taints the `spark_benchmark_ebs` nodegroup and adds tolerations to the job template

### Motivation
Prefix delegation helps increase the pod density from 58 -> 90+ per node. 
Tainting the nodegroup helps avoid issues with Prometheus and other controllers being deployed on those node groups. 

### More

- [x] Yes, I have tested the PR using my local account setup (Provide any test evidence report under Additional Notes)
- [ ] Mandatory for new blueprints. Yes, I have added a example to support my blueprint PR
- [ ] Mandatory for new blueprints. Yes, I have updated the `website/docs` or `website/blog` section for this feature
- [ ] Yes, I ran `pre-commit run -a` with this PR. Link for installing [pre-commit](https://pre-commit.com/) locally

### For Moderators

- [ ] E2E Test successfully complete before merge?

### Additional Notes
**Note:** I think its recommended to recreate the nodegroups after setting the prefix delegation options on existing nodes. I went through a full stack recreation and did not test the migration path here.
